### PR TITLE
build: cache yarn dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,10 @@ jobs:
         with:
           node-version: 14.x
 
-      - name: Install dependencies
-        run: yarn install
+      - name: Install dependencies w/ cache
+        uses: bahmutov/npm-install@v1
+        with:
+          install-command: yarn --immutable
 
       - name: Create Release
         env:


### PR DESCRIPTION
## Motivation

- Since we're not doing yarn zero-installs yet, caching is needed to avoid re-downloading everything dependency on each run. 

## Notes

- Docs on the linked github action: https://github.com/bahmutov/npm-install
- This will be unnecessary if we switch to a yarn v2 zero-install setup.