### PR TITLE
refactor: import plugin ID from constants

### DIFF
--- a/src/preset/manager.ts
+++ b/src/preset/manager.ts
@@ -10,7 +10,10 @@ import { STORY_ERRORED, STORY_MISSING } from '@storybook/core-events';
 
 import { datadogRum } from '@datadog/browser-rum'
 
-addons.register('storybook/datadog-rum', (api) => {
+import { ADDON_ID } from '../constants';
+
+
+addons.register(ADDON_ID, (api) => {
   datadogRum.init({
     applicationId: globalWindow.STORYBOOK_DATADOG_APPLICATION_ID,
     clientToken: globalWindow.STORYBOOK_DATADOG_CLIENT_TOKEN,


### PR DESCRIPTION
## Motivation

A small non-functional change to check the behavior of the release process, now that `auto create-labels` ran once first.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.4-canary.7.2d384b7.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-datadog-rum@0.1.4-canary.7.2d384b7.0
  # or 
  yarn add storybook-addon-datadog-rum@0.1.4-canary.7.2d384b7.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
