### PR TITLE
feat: enable version tag to be customized via environment variable

### DIFF
--- a/preset.js
+++ b/preset.js
@@ -2,7 +2,9 @@ function config(entry = []) {
   return [...entry, require.resolve("./dist/esm/preset/preview")];
 }
 
-function managerEntries(entry = []) {
+// TODO: https://github.com/storybookjs/addon-kit/issues/16#issuecomment-870201802
+// Figure out if it's possible to pass config from presetOptions into manager.ts
+function managerEntries(entry = [], presetOptions) {
   return [...entry, require.resolve("./dist/esm/preset/manager")];
 }
 

--- a/src/preset/manager.ts
+++ b/src/preset/manager.ts
@@ -3,7 +3,6 @@
 // No need to manually instrument page views due to usage of history API
 //  - https://docs.datadoghq.com/real_user_monitoring/browser/data_collected/?tab=view#single-page-applications
 
-
 import { window as globalWindow } from 'global';
 import { addons } from '@storybook/addons';
 import { STORY_ERRORED, STORY_MISSING } from '@storybook/core-events';
@@ -20,9 +19,9 @@ addons.register(ADDON_ID, (api) => {
     site: globalWindow.STORYBOOK_DATADOG_SITE,
     service: globalWindow.STORYBOOK_DATADOG_SERVICE ?? 'storybook-default',
     //  env: 'production',
-    //  version: '1.0.0',
+    version: globalWindow.STORYBOOK_DATADOG_VERSION ?? '0.1.0',
     sampleRate: globalWindow.STORYBOOK_DATADOG_SAMPLE_RATE ?? 100,
-    trackInteractions: globalWindow.STORYBOOK_DATADOG_TRACK_INTERACTIONS?? true,
+    trackInteractions: globalWindow.STORYBOOK_DATADOG_TRACK_INTERACTIONS ?? true,
   })
 
   api.on(STORY_ERRORED, ({ description }: { description: string }) => {

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -6,5 +6,6 @@ declare module "global" {
     STORYBOOK_DATADOG_SERVICE?: string;
     STORYBOOK_DATADOG_SAMPLE_RATE?: number;
     STORYBOOK_DATADOG_TRACK_INTERACTIONS?: boolean;
+    STORYBOOK_DATADOG_VERSION?: string;
   }
 };


### PR DESCRIPTION
## Motivation

- Make a small functional change
- Check if auto creates a pre-release when this merges to `main` , and publishes an actual release when `main` is merged to stable.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.0-canary.8.98832a6.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-datadog-rum@0.2.0-canary.8.98832a6.0
  # or 
  yarn add storybook-addon-datadog-rum@0.2.0-canary.8.98832a6.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.2.0-main.0`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - feat: enable version tag to be customized via environment variable [#8](https://github.com/hydrosquall/storybook-addon-datadog-rum/pull/8) ([@hydrosquall](https://github.com/hydrosquall))
  
  #### 🐛 Bug Fix
  
  - refactor: import plugin ID from constants [#7](https://github.com/hydrosquall/storybook-addon-datadog-rum/pull/7) ([@hydrosquall](https://github.com/hydrosquall))
  - build: cache yarn dependencies [#6](https://github.com/hydrosquall/storybook-addon-datadog-rum/pull/6) ([@hydrosquall](https://github.com/hydrosquall))
  
  #### Authors: 1
  
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
