### PR TITLE
build: update internal pre-release branch to "next"

### DIFF
--- a/auto.config.js
+++ b/auto.config.js
@@ -19,7 +19,7 @@ function rc() {
 
     baseBranch: "stable",        // latest "official" version
     // TODO: consider renaming this branch to "next"
-    prereleaseBranches: ["main"] // cutting-edge versions
+    prereleaseBranches: ["next"] // cutting-edge versions
   };
 }
 


### PR DESCRIPTION
## Motivation

- "prerelease" branches take the suffix of their parent branch.  `main` is not a good name, as (`next`, `alpha`, `beta` are clearer). 
  - From the previous test, when `main` was made to be a pre-release branch, it published a library with the name `main` https://www.npmjs.com/package/storybook-addon-datadog-rum/v/0.2.0-main.0

- I'm going to follow this up by deleting the `main` branch, everything should be done on `next` or `stable`. 

## Docs

- https://intuit.github.io/auto/docs/generated/shipit#prereleases