### PR TITLE
feat: enable setting RUM env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To run this project, you will need to add the following environment variables to
     STORYBOOK_DATADOG_SAMPLE_RATE?: number;
     STORYBOOK_DATADOG_TRACK_INTERACTIONS?: boolean;
     STORYBOOK_DATADOG_VERSION?: string;
+    STORYBOOK_DATADOG_ENV?: string;
 }
 ```
 

--- a/src/preset/manager.ts
+++ b/src/preset/manager.ts
@@ -18,7 +18,7 @@ addons.register(ADDON_ID, (api) => {
     clientToken: globalWindow.STORYBOOK_DATADOG_CLIENT_TOKEN,
     site: globalWindow.STORYBOOK_DATADOG_SITE,
     service: globalWindow.STORYBOOK_DATADOG_SERVICE ?? 'storybook-default',
-    //  env: 'production',
+    env: globalWindow.STORYBOOK_DATADOG_ENV ?? undefined,
     version: globalWindow.STORYBOOK_DATADOG_VERSION ?? '0.1.0',
     sampleRate: globalWindow.STORYBOOK_DATADOG_SAMPLE_RATE ?? 100,
     trackInteractions: globalWindow.STORYBOOK_DATADOG_TRACK_INTERACTIONS ?? true,

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -7,5 +7,6 @@ declare module "global" {
     STORYBOOK_DATADOG_SAMPLE_RATE?: number;
     STORYBOOK_DATADOG_TRACK_INTERACTIONS?: boolean;
     STORYBOOK_DATADOG_VERSION?: string;
+    STORYBOOK_DATADOG_ENV?: string;
   }
 };


### PR DESCRIPTION
## Motivation

- Differentiate between staging and production activity

## Testing

- Tested in an internal app, confirmed the tag can toggle between staging and production by changing the value of this variable.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.3.0-canary.12.9a5ed27.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-datadog-rum@0.3.0-canary.12.9a5ed27.0
  # or 
  yarn add storybook-addon-datadog-rum@0.3.0-canary.12.9a5ed27.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.3.0-next.1`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - feat: enable setting RUM env variable [#12](https://github.com/hydrosquall/storybook-addon-datadog-rum/pull/12) ([@hydrosquall](https://github.com/hydrosquall))
  
  #### 🐛 Bug Fix
  
  - docs: document version attribute [#11](https://github.com/hydrosquall/storybook-addon-datadog-rum/pull/11) ([@hydrosquall](https://github.com/hydrosquall))
  - build: update internal pre-release branch to "next" [#10](https://github.com/hydrosquall/storybook-addon-datadog-rum/pull/10) ([@hydrosquall](https://github.com/hydrosquall))
  
  #### ⚠️ Pushed to `next`
  
  - build: remove import of unused preview file ([@hydrosquall](https://github.com/hydrosquall))
  - docs: document publish/release process ([@hydrosquall](https://github.com/hydrosquall))
  
  #### Authors: 1
  
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
