### PR TITLE
chore: release new patch version

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,6 @@
+This document outlines some of the process
+
+## Publishing
+
+- This project uses the auto shipit `next` [branching strategy](https://intuit.github.io/auto/docs/generated/shipit#next-branch-default). All prs should be merged into `next` by default.
+- To release a new version on npm that is tagged with `latest`, [open a PR from next to stable](https://github.com/hydrosquall/storybook-addon-datadog-rum/compare/stable...next?expand=1).

--- a/README.md
+++ b/README.md
@@ -44,10 +44,9 @@ To run this project, you will need to add the following environment variables to
 
 Contributions are always welcome!
 
-See [`contributing.md`](./CONTRIBUTING.md) for ways to get started.
+See [`contributing.md`](./CONTRIBUTING.md) for ways to get started, and [`MAINTAINERS`](./MAINTAINERS.md) to learn how to publish the library
 
 Please adhere to this project's `code of conduct`.
-
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To run this project, you will need to add the following environment variables to
     STORYBOOK_DATADOG_SAMPLE_RATE?: number;
     STORYBOOK_DATADOG_TRACK_INTERACTIONS?: boolean;
     STORYBOOK_DATADOG_VERSION?: string;
+    STORYBOOK_DATADOG_ENV?: string;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ To run this project, you will need to add the following environment variables to
 ```
 
 [Full initialization parameters documentation](https://docs.datadoghq.com/real_user_monitoring/browser/#initialization-parameters)
+
+Then, read them in your `manager.js`.
+
+```js
+window.STORYBOOK_DATADOG_APPLICATION_ID = process.env.STORYBOOK_DATADOG_APPLICATION_ID;
+window.STORYBOOK_DATADOG_CLIENT_TOKEN = process.env.STORYBOOK_DATADOG_CLIENT_TOKEN;
+window.STORYBOOK_DATADOG_SITE = process.env.STORYBOOK_DATADOG_SITE;
+window.STORYBOOK_DATADOG_SERVICE = process.env.STORYBOOK_DATADOG_SERVICE;
+```
+
 ## Contributing
 
 Contributions are always welcome!

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To run this project, you will need to add the following environment variables to
     STORYBOOK_DATADOG_SERVICE?: string;
     STORYBOOK_DATADOG_SAMPLE_RATE?: number;
     STORYBOOK_DATADOG_TRACK_INTERACTIONS?: boolean;
+    STORYBOOK_DATADOG_VERSION?: string;
 }
 ```
 

--- a/auto.config.js
+++ b/auto.config.js
@@ -19,7 +19,7 @@ function rc() {
 
     baseBranch: "stable",        // latest "official" version
     // TODO: consider renaming this branch to "next"
-    prereleaseBranches: ["main"] // cutting-edge versions
+    prereleaseBranches: ["next"] // cutting-edge versions
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -90,6 +90,6 @@
     "icon": "https://user-images.githubusercontent.com/321738/63501763-88dbf600-c4cc-11e9-96cd-94adadc2fd72.png"
   },
   "dependencies": {
-    "@datadog/browser-rum": "^2.13.0"
+    "@datadog/browser-rum": "^2.18.0"
   }
 }

--- a/preset.js
+++ b/preset.js
@@ -9,6 +9,5 @@ function managerEntries(entry = [], presetOptions) {
 }
 
 module.exports = {
-  managerEntries,
-  config,
+  managerEntries
 };

--- a/preset.js
+++ b/preset.js
@@ -1,6 +1,6 @@
-function config(entry = []) {
-  return [...entry, require.resolve("./dist/esm/preset/preview")];
-}
+// function config(entry = []) {
+//   return [...entry, require.resolve("./dist/esm/preset/preview")];
+// }
 
 // TODO: https://github.com/storybookjs/addon-kit/issues/16#issuecomment-870201802
 // Figure out if it's possible to pass config from presetOptions into manager.ts

--- a/src/preset/manager.ts
+++ b/src/preset/manager.ts
@@ -5,7 +5,7 @@
 
 import { window as globalWindow } from 'global';
 import { addons } from '@storybook/addons';
-import { STORY_ERRORED, STORY_MISSING } from '@storybook/core-events';
+import { STORY_ERRORED, STORY_MISSING, STORY_CHANGED } from '@storybook/core-events';
 
 import { datadogRum } from '@datadog/browser-rum'
 
@@ -13,6 +13,7 @@ import { ADDON_ID } from '../constants';
 
 
 addons.register(ADDON_ID, (api) => {
+
   datadogRum.init({
     applicationId: globalWindow.STORYBOOK_DATADOG_APPLICATION_ID,
     clientToken: globalWindow.STORYBOOK_DATADOG_CLIENT_TOKEN,
@@ -22,11 +23,18 @@ addons.register(ADDON_ID, (api) => {
     version: globalWindow.STORYBOOK_DATADOG_VERSION ?? '0.1.0',
     sampleRate: globalWindow.STORYBOOK_DATADOG_SAMPLE_RATE ?? 100,
     trackInteractions: globalWindow.STORYBOOK_DATADOG_TRACK_INTERACTIONS ?? true,
-  })
+  });
+
+  api.on(STORY_CHANGED, () => {
+    const { path } = api.getUrlState();
+    // https://github.com/DataDog/browser-sdk/pull/924
+    datadogRum.startView(path);
+  });
 
   api.on(STORY_ERRORED, ({ description }: { description: string }) => {
     datadogRum.addError( description )
   });
+
   api.on(STORY_MISSING, (id: string) => {
     const description = `attempted to render ${id}, but it is missing`
     datadogRum.addError(description);

--- a/src/preset/manager.ts
+++ b/src/preset/manager.ts
@@ -18,7 +18,7 @@ addons.register(ADDON_ID, (api) => {
     clientToken: globalWindow.STORYBOOK_DATADOG_CLIENT_TOKEN,
     site: globalWindow.STORYBOOK_DATADOG_SITE,
     service: globalWindow.STORYBOOK_DATADOG_SERVICE ?? 'storybook-default',
-    //  env: 'production',
+    env: globalWindow.STORYBOOK_DATADOG_ENV ?? undefined,
     version: globalWindow.STORYBOOK_DATADOG_VERSION ?? '0.1.0',
     sampleRate: globalWindow.STORYBOOK_DATADOG_SAMPLE_RATE ?? 100,
     trackInteractions: globalWindow.STORYBOOK_DATADOG_TRACK_INTERACTIONS ?? true,

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -7,5 +7,6 @@ declare module "global" {
     STORYBOOK_DATADOG_SAMPLE_RATE?: number;
     STORYBOOK_DATADOG_TRACK_INTERACTIONS?: boolean;
     STORYBOOK_DATADOG_VERSION?: string;
+    STORYBOOK_DATADOG_ENV?: string;
   }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,33 +2042,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/browser-core@npm:2.13.0":
-  version: 2.13.0
-  resolution: "@datadog/browser-core@npm:2.13.0"
+"@datadog/browser-core@npm:2.18.0":
+  version: 2.18.0
+  resolution: "@datadog/browser-core@npm:2.18.0"
   dependencies:
     tslib: ^1.10.0
-  checksum: dfa2ca6690b0b2eb0327d00862492489997558eed27a10c9b7f088f858b304014945b8b895949a17a25c7ed1c11e1c60bb4c276cea76a876ec2f71c2797257b2
+  checksum: 8da1e843361730e39a31c67e992fa1e0c758516920f554827a49df7f8baa6f67be173e17dee25a99dfa56b82fae4ce1f47fff34912a23c6ac1bc55e3465c999a
   languageName: node
   linkType: hard
 
-"@datadog/browser-rum-core@npm:2.13.0":
-  version: 2.13.0
-  resolution: "@datadog/browser-rum-core@npm:2.13.0"
+"@datadog/browser-rum-core@npm:2.18.0":
+  version: 2.18.0
+  resolution: "@datadog/browser-rum-core@npm:2.18.0"
   dependencies:
-    "@datadog/browser-core": 2.13.0
+    "@datadog/browser-core": 2.18.0
     tslib: ^1.10.0
-  checksum: 79442f23d670798099ebcde3a23ffbf605786ccbe3b150a0e8c2d0ff5abc1d161d8043d19b90f2cb87a5e8bacfbbeb0a53a34050c45081fa592c998c7e10b932
+  checksum: 3f2450a1b56411a8732a0ba99ca0af5b3de3bb426069db46dabce60d84a9a4d002456e7e92e81428e7552a06592693b41a1d268805e85a79b4c05b15b7ccda4d
   languageName: node
   linkType: hard
 
-"@datadog/browser-rum@npm:^2.13.0":
-  version: 2.13.0
-  resolution: "@datadog/browser-rum@npm:2.13.0"
+"@datadog/browser-rum@npm:^2.18.0":
+  version: 2.18.0
+  resolution: "@datadog/browser-rum@npm:2.18.0"
   dependencies:
-    "@datadog/browser-core": 2.13.0
-    "@datadog/browser-rum-core": 2.13.0
+    "@datadog/browser-core": 2.18.0
+    "@datadog/browser-rum-core": 2.18.0
     tslib: ^1.10.0
-  checksum: d94ae7b97d0dba270036ed3f16573d42ebf91221e8de2e1901866ee5ffa945de9d4f716bbb709a307afe249c1a08c6a7dd1121ac800ec39b32bc4a9e32a86d94
+  checksum: 1f6e09bbcc9142ce665bddf808c65be9dce279379ccb70d326a54830f61285c5fed1d107c65ff433add8bcb15e98c29114be591e9b9b41c9187e6b73dd2aae4c
   languageName: node
   linkType: hard
 
@@ -13261,7 +13261,7 @@ resolve@~1.7.1:
     "@babel/preset-env": ^7.12.1
     "@babel/preset-react": ^7.12.5
     "@babel/preset-typescript": ^7.13.0
-    "@datadog/browser-rum": ^2.13.0
+    "@datadog/browser-rum": ^2.18.0
     "@storybook/addon-essentials": ^6.2.9
     "@storybook/addons": 6.2.9
     "@storybook/core-events": 6.2.9


### PR DESCRIPTION
Check the version bump based on PR label (`patch`) instead of parsing commit messages (which would yield `minor`)
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v0.3.0-next.2`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - feat: track storybook story path changes [#14](https://github.com/hydrosquall/storybook-addon-datadog-rum/pull/14) ([@hydrosquall](https://github.com/hydrosquall))
  - feat: enable setting RUM env variable [#12](https://github.com/hydrosquall/storybook-addon-datadog-rum/pull/12) ([@hydrosquall](https://github.com/hydrosquall))
  
  #### 🐛 Bug Fix
  
  - docs: document version attribute [#11](https://github.com/hydrosquall/storybook-addon-datadog-rum/pull/11) ([@hydrosquall](https://github.com/hydrosquall))
  - build: update internal pre-release branch to "next" [#10](https://github.com/hydrosquall/storybook-addon-datadog-rum/pull/10) ([@hydrosquall](https://github.com/hydrosquall))
  
  #### ⚠️ Pushed to `next`
  
  - build: remove import of unused preview file ([@hydrosquall](https://github.com/hydrosquall))
  - docs: document publish/release process ([@hydrosquall](https://github.com/hydrosquall))
  
  #### Authors: 1
  
  - Cameron Yick ([@hydrosquall](https://github.com/hydrosquall))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
